### PR TITLE
expand variable substitution matching

### DIFF
--- a/behaviors/text.lua
+++ b/behaviors/text.lua
@@ -64,7 +64,7 @@ function TextBehavior:parseContent(component, performing, variableNameToValue)
 
    -- parse variables
    local output = component.properties.content:gsub(
-      "(%$%w+)",
+      "(%$[%w_-]+)",
       function(maybeVariable)
             local variableName = string.sub(maybeVariable, 2)
             if variableNameToValue[variableName] ~= nil then


### PR DESCRIPTION
This PR changes the pattern for variable substitution on text boxes to match any valid JavaScript variable name including names with dashes and underscores.

Current matching (substitutes variable value in textboxes):
$test ✔️
$18 ✔️
$my_variable ❌
$movement-speed ❌

Updated matching:
$test ✔️
$my_variable ✔️
$amount-of-cats ✔️

Alternatively, the pattern `"(%$%S+)"` will match all variable-like patterns, while still delimiting at whitespace. This may be preferable so that allowed variable names can simply be limited by what the variable creation page will accept and it is equally backward compatible even if *entering* certain variable names is later disabled.